### PR TITLE
Added UMD support for VolumetricFire

### DIFF
--- a/VolumetricFire.js
+++ b/VolumetricFire.js
@@ -8,7 +8,20 @@
  * https://www.iusb.edu/math-compsci/_prior-thesis/YVanzine_thesis.pdf
  */
 
-var VolumetricFire = ( function () {
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define([], factory);
+  } else if (typeof module === 'object' && module.exports) {
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like environments that support module.exports,
+    // like Node.
+    module.exports = factory();
+  } else {
+    // Browser globals (root is window)
+    root.VolumetricFire = factory(root);
+  }
+}(this, function () {
 
   'use strict';
 
@@ -605,4 +618,4 @@ var VolumetricFire = ( function () {
 
   return VolumetricFire;
 
-} )();
+}));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "volumetric-fire",
+  "version": "0.0.0",
+  "description": "UMD support for VolumetricFire",
+  "main": "VolumetricFire.js",
+  "directories": {
+    "example": "examples"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stanford-gfx/VolumetricFire.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/stanford-gfx/VolumetricFire/issues"
+  },
+  "homepage": "https://github.com/stanford-gfx/VolumetricFire#readme"
+}


### PR DESCRIPTION
Hi @yomotsu ,
This PR adds UMD support to your module. This means the module can additionally be `require`d as in Node (which is helpful if people want to include this file as part of a js bundle via webpack/browserify) and also work with AMD. UMD also means it's backwards compatible so this module can be used as a browser global.

Not sure how familiar you are with CommonJS syntax, but that basically means the module can be loaded as follows:

```
var VolumetricFire = require('volumetric-fire');
```

You will have to modify the package.json before/after you merge in this PR, and you may also want to publish your package to NPM.
